### PR TITLE
Diagonal search

### DIFF
--- a/src/team4player/Miner.java
+++ b/src/team4player/Miner.java
@@ -39,12 +39,12 @@ public class Miner extends Unit{
 		public void checkForSoup() throws GameActionException{
 				MapLocation[] soup = rc.senseNearbySoup(-1);
 				if (soup != null && soup.length != 0) { // we found soup! Head towards it
-						int randomLoc = (int) Math.random() * soup.length + 0; // random soup to avoid crowds
+						boolean mined = false; // checks if  we need to move areas for soup
 						for (Direction dir : Util.directions){
 								if(tryMine(dir)){mined = true;}
 						}
-						boolean mined = false;
-						if (!mined){ // checks if  we need to move areas for soup
+						if (!mined){
+							int randomLoc = (int) (Math.random() * soup.length + 0); // random soup to avoid crowds
 						  walkTowardsSoup(soup, randomLoc);}
 				} else {
 					System.out.println("GOING DIAGONAL DIRECTION"); // we can be stuck


### PR DESCRIPTION
Moved miners diagonally...also changed the order in which miners do things (e.g., mine around them and then go to refinery if the mining was unsuccessful). Netgain is overall speedups in miner production and also miners are able to cover a wider surface area. 

However, there may be other speedups that can occur that I have not yet put in (e.g., moving N, S, E, or W instead of any direction randomly when a miners direction does not work.